### PR TITLE
Make getTokenOptions argument optional

### DIFF
--- a/src/authStore.ts
+++ b/src/authStore.ts
@@ -21,7 +21,7 @@ type AuthState<TUser extends User = User> = {
   setError: (error: Error) => void
   loginWithRedirect: (loginOptions?: RedirectLoginOptions) => Promise<void>
   logout: (logoutOptions?: LogoutOptions) => Promise<void>
-  getAccessTokenSilently: (getTokenOptions: GetTokenSilentlyOptions) => Promise<string>
+  getAccessTokenSilently: (getTokenOptions?: GetTokenSilentlyOptions) => Promise<string>
   getIdTokenClaims: () => Promise<IdToken | undefined>
 }
 


### PR DESCRIPTION
## Description
The argument `getTokenOptions` of the function `getAccessTokenSilently` in the `authStore` is now optional as in the original Auth0 SDK.