### PR TITLE
Add example to get access token

### DIFF
--- a/example/src/Nav.tsx
+++ b/example/src/Nav.tsx
@@ -7,6 +7,7 @@ export function Nav() {
   const user = useAuth(state => state.user)
   const logout = useAuth(state => state.logout)
   const loginWithRedirect = useAuth(state => state.loginWithRedirect)
+  const getAccessTokenSilently = useAuth(state => state.getAccessTokenSilently)
 
   const { pathname } = useLocation()
 
@@ -38,6 +39,13 @@ export function Nav() {
           <span id="hello">Hello, {user?.name}!</span>{' '}
           <button className="btn btn-outline-secondary" id="logout" onClick={() => logout()}>
             logout
+          </button>
+          <button
+            className="btn btn-outline-secondary"
+            id="get-token"
+            onClick={() => getAccessTokenSilently().then(console.log).catch(console.log)}
+          >
+            get access token
           </button>
         </div>
       ) : (


### PR DESCRIPTION
## Description

This PR adds a new button in the `Nav` to retrieve the access token.

## Considerations

This is just a simple example to enable us to quickly get access tokens for testing purposes.